### PR TITLE
Fix url for rails plugin

### DIFF
--- a/cookbooks/projects/files/default/bash_profile
+++ b/cookbooks/projects/files/default/bash_profile
@@ -2,4 +2,4 @@ export PATH=/usr/local/bin:$PATH
 which rbenv > /dev/null 2>&1
 test $? -eq 0 && eval "$(rbenv init -)"
 
-curl -fsSL https://raw.githubusercontent.com/robbyrussell/oh-my-zsh/master/plugins/rails/rails.plugin.zsh | sed -e "/compdef/d" | sh
+curl -fsSL https://raw.githubusercontent.com/sachin21/oh-my-zsh/for_wantedly_cooker/plugins/rails/rails.plugin.zsh | sh


### PR DESCRIPTION
# WHY

defaultのmacのaliasコマンドで`-g`オプションが使えないみたいです。
ですが、coreutilsで今も管理してあるaliasでは使えるみたい。
なのでalias -gを使えってるaliasコマンドは消しました。
# HOW

sachin21/oh-my-zshでforkしてfor_wantedly branchにcurlするという解決策を提案してみます。
バグをcommitしてすみません。。
